### PR TITLE
Update README for markdown compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Exercises for Intro to Algorithms and Data Structures in JavaScript
+# Exercises for Intro to Algorithms and Data Structures in JavaScript
 
 Welcome to the exercises. This is where the magic happens! 
 
-###Monday - June 13th
+### Monday - June 13th
 1. Implement a stack data structure:
   - https://github.com/kuychaco/algoClass/blob/master/data-structures/stack.js
   - Note: only do the first exercise after you implement the stack
@@ -15,7 +15,7 @@ Welcome to the exercises. This is where the magic happens!
   - https://github.com/kuychaco/algoClass/tree/master/recursion
   - Note: some of these will only click after we go through sorting, graphs & trees later this week.
 
-###Tuesday - June 14th
+### Tuesday - June 14th
 1. Implement the elementary sorting algorithms (bubble, insertion, selection):
   - https://github.com/kuychaco/algoClass/tree/master/sorting-algorithms
 2. Implement Mergesort
@@ -33,13 +33,13 @@ Welcome to the exercises. This is where the magic happens!
   - Note: Hold off on Depth First Search and Breadth First Search because we haven't covered that yet.
 3. This is a catch up day so use the rest of the afternoon to finish up exercises from previous days and review anything that was confusing. 
 
-###Thursday - June 16th
+### Thursday - June 16th
 1. Binary Search Tree
   - https://github.com/kuychaco/algoClass/blob/master/data-structures/binarySearchTree.js
 2. Binary Search Array
   - https://github.com/kuychaco/algoClass/blob/master/searching-algorithms/binarySearchArray.js
 
-###Friday - June 17th
+### Friday - June 17th
 1. Binary Search Tree (delete nodes)
   - https://github.com/kuychaco/algoClass/blob/master/data-structures/binarySearchTree.js
 2. Implement a graph
@@ -51,6 +51,6 @@ Welcome to the exercises. This is where the magic happens!
 5. [Bonus] BFS/DFS for tree
   - https://github.com/kuychaco/algoClass/blob/master/data-structures/tree.js
 
-###Saturday - June 18th
+### Saturday - June 18th
 1. Create your own Hash Tables! Watch out for those collisions!
   - https://github.com/kuychaco/algoClass/blob/master/data-structures/hashTable.js


### PR DESCRIPTION
GitHub has a new MD specification that they follow, which you can [read about here](https://githubengineering.com/a-formal-spec-for-github-markdown/). Basically, it's a little more strict. For example, headings must now be followed by a space.